### PR TITLE
Make test data providers in multiple files static

### DIFF
--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -99,6 +99,22 @@ class EmailTest extends PHPUnit
         is(null, Email::getGravatarUrl(''));
     }
 
+    public function testRandomEmail(): void
+    {
+        isTrue((bool)Email::check(Email::random()));
+        isTrue(Email::isValid(Email::random()));
+
+        isNotSame(Email::random(), Email::random());
+        isNotSame(Email::random(), Email::random());
+        isNotSame(Email::random(), Email::random());
+    }
+
+    public function testCheckDns(): void
+    {
+        isFalse(Email::checkDns('123'));
+        isTrue(Email::checkDns('denis@gmail.com'));
+    }
+
     public static function provideCheckCases(): iterable
     {
         return [
@@ -250,21 +266,5 @@ class EmailTest extends PHPUnit
                 'https://secure.gravatar.com/avatar/f27f28ab2158cd2cccc78c364d6247fe/?s=2048&d=identicon',
             ],
         ];
-    }
-
-    public function testRandomEmail(): void
-    {
-        isTrue((bool)Email::check(Email::random()));
-        isTrue(Email::isValid(Email::random()));
-
-        isNotSame(Email::random(), Email::random());
-        isNotSame(Email::random(), Email::random());
-        isNotSame(Email::random(), Email::random());
-    }
-
-    public function testCheckDns(): void
-    {
-        isFalse(Email::checkDns('123'));
-        isTrue(Email::checkDns('denis@gmail.com'));
     }
 }

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -99,7 +99,7 @@ class EmailTest extends PHPUnit
         is(null, Email::getGravatarUrl(''));
     }
 
-    public function provideCheckCases(): iterable
+    public static function provideCheckCases(): iterable
     {
         return [
             [
@@ -128,7 +128,7 @@ class EmailTest extends PHPUnit
         ];
     }
 
-    public function provideGetDomainsCases(): iterable
+    public static function provideGetDomainsCases(): iterable
     {
         return [
             [
@@ -166,7 +166,7 @@ class EmailTest extends PHPUnit
         ];
     }
 
-    public function provideGetDomainsInAlphabeticalOrderCases(): iterable
+    public static function provideGetDomainsInAlphabeticalOrderCases(): iterable
     {
         return [
             [
@@ -199,12 +199,12 @@ class EmailTest extends PHPUnit
         ];
     }
 
-    public function getEmptyProvider(): iterable
+    public static function getEmptyProvider(): iterable
     {
         return [[[]], [false], [''], [0]];
     }
 
-    public function provideGetGravatarUrlCases(): iterable
+    public static function provideGetGravatarUrlCases(): iterable
     {
         return [
             0 => [

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -24,34 +24,6 @@ use JBZoo\Utils\Filter;
  */
 class EnvTest extends PHPUnit
 {
-    public static function provideConvertOptionsCases(): iterable
-    {
-        return [
-            ['NULL', Env::VAR_NULL, null],
-            ['null', Env::VAR_NULL, null],
-
-            ['false', Env::VAR_BOOL, false],
-            ['FALSE', Env::VAR_BOOL, false],
-            ['0', Env::VAR_BOOL, false],
-            ['true', Env::VAR_BOOL, true],
-            ['True', Env::VAR_BOOL, true],
-            ['1', Env::VAR_BOOL, true],
-
-            ['42', Env::VAR_INT, 42],
-            ['FALSE', Env::VAR_INT, 0],
-
-            ['42.42', Env::VAR_FLOAT, 42.42],
-            ['42', Env::VAR_FLOAT, 42.0],
-            ['FALSE', Env::VAR_FLOAT, 0.],
-
-            ['"hello"', Env::VAR_STRING, 'hello'],
-            ["'hello'", Env::VAR_STRING, 'hello'],
-
-            ['"hello"', 0, '"hello"'],
-            ["'hello'", 0, "'hello'"],
-        ];
-    }
-
     /**
      * @dataProvider provideConvertOptionsCases
      * @param mixed $value
@@ -140,5 +112,33 @@ class EnvTest extends PHPUnit
         isTrue(Env::isExists('FOO_STRING_2'));
         isTrue(Env::isExists('FOO_EMPTY_2'));
         isFalse(Env::isExists('FOO_QWERTY_2'));
+    }
+
+    public static function provideConvertOptionsCases(): iterable
+    {
+        return [
+            ['NULL', Env::VAR_NULL, null],
+            ['null', Env::VAR_NULL, null],
+
+            ['false', Env::VAR_BOOL, false],
+            ['FALSE', Env::VAR_BOOL, false],
+            ['0', Env::VAR_BOOL, false],
+            ['true', Env::VAR_BOOL, true],
+            ['True', Env::VAR_BOOL, true],
+            ['1', Env::VAR_BOOL, true],
+
+            ['42', Env::VAR_INT, 42],
+            ['FALSE', Env::VAR_INT, 0],
+
+            ['42.42', Env::VAR_FLOAT, 42.42],
+            ['42', Env::VAR_FLOAT, 42.0],
+            ['FALSE', Env::VAR_FLOAT, 0.],
+
+            ['"hello"', Env::VAR_STRING, 'hello'],
+            ["'hello'", Env::VAR_STRING, 'hello'],
+
+            ['"hello"', 0, '"hello"'],
+            ["'hello'", 0, "'hello'"],
+        ];
     }
 }

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -24,7 +24,7 @@ use JBZoo\Utils\Filter;
  */
 class EnvTest extends PHPUnit
 {
-    public function provideConvertOptionsCases(): iterable
+    public static function provideConvertOptionsCases(): iterable
     {
         return [
             ['NULL', Env::VAR_NULL, null],

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -32,7 +32,7 @@ class FilterTest extends PHPUnit
         isSame($exepted, Filter::_($actual, 'int'));
     }
 
-    public function provideIntCases(): iterable
+    public static function provideIntCases(): iterable
     {
         return [
             [0, null],
@@ -70,7 +70,7 @@ class FilterTest extends PHPUnit
         }
     }
 
-    public function provideFloatCases(): iterable
+    public static function provideFloatCases(): iterable
     {
         return [
             [0.0, null],
@@ -112,7 +112,7 @@ class FilterTest extends PHPUnit
         isSame($excepted, Filter::_($actual, 'bool'));
     }
 
-    public function provideBoolCases(): iterable
+    public static function provideBoolCases(): iterable
     {
         return [
             [true, '1'],

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -32,29 +32,6 @@ class FilterTest extends PHPUnit
         isSame($exepted, Filter::_($actual, 'int'));
     }
 
-    public static function provideIntCases(): iterable
-    {
-        return [
-            [0, null],
-            [0, false],
-            [0, ''],
-            [0, 0],
-            [1, 1],
-            [1, '1'],
-            [1, '01'],
-            [-1, '-01'],
-            [-15, ' - 1 5 '],
-            [-17, ' - 1 asd 7 '],
-            [-1, ' - 1 . 0 '],
-            [-1, ' - 1 , 5 '],
-            [-1, ' - 1 - 0 '],
-            [3, ' + 3'],
-            [-4, ' - 4'],
-            [-5, ' +- 5'],
-            [6, ' -+ 6'],
-        ];
-    }
-
     /**
      * @dataProvider provideFloatCases
      * @param mixed      $excepted
@@ -70,38 +47,6 @@ class FilterTest extends PHPUnit
         }
     }
 
-    public static function provideFloatCases(): iterable
-    {
-        return [
-            [0.0, null],
-            [0.0, false],
-            [0.0, ''],
-            [0.0, 'asdasd'],
-            [0.0, 0],
-            [1.0, 1],
-            [123456789.0, 123456789],
-            [1.0, '1'],
-            [1.0, '01'],
-            [-1.0, '-01'],
-            [-10.0, ' - 1 0 '],
-            [-1.5, ' - 1,5 '],
-            [-1.5, ' - 1.5 '],
-            [-1.512, ' - 1.5123 ', 3],
-            [-15123.0, ' - 1 asd 5123 ', 3],
-            [15123.0, ' + 1 asd 5123 ', 3],
-
-            [-12.451, 'abc-12,451'],
-            [-12.452, 'abc-12.452'],
-            [-12.453, '-abc12.453'],
-            [-12.454, 'abc-12.454abc'],
-            [-12.455, 'abc-12. 455'],
-            [-12.456, 'abc-12. 456 .7'],
-            [2.6e-19, '26.3e-20', 20],
-            [2.53E-19, '25.3e-20', 100],
-            [2.4e-9, '24.3e-10'],
-        ];
-    }
-
     /**
      * @dataProvider provideBoolCases
      * @param mixed $excepted
@@ -110,60 +55,6 @@ class FilterTest extends PHPUnit
     public function testBool($excepted, $actual): void
     {
         isSame($excepted, Filter::_($actual, 'bool'));
-    }
-
-    public static function provideBoolCases(): iterable
-    {
-        return [
-            [true, '1'],
-            [true, ' 1'],
-            [true, '1 '],
-            [true, '10'],
-            [true, '-1'],
-            [true, true],
-            [true, 27],
-            [true, 1.0],
-            [true, -1],
-            [true, -1.0],
-            [true, 10],
-            [true, 10.0],
-            [true, 10.0],
-            [true, 'true'],
-            [true, 'TRUE'],
-            [true, 'yes'],
-            [true, 'YES'],
-            [true, 'y'],
-            [true, 'Y'],
-            [true, 'oui'],
-            [true, 'vrai'],
-            [true, 'ДА'],
-            [true, 'Д'],
-            [true, '*'],
-            [true, '+'],
-            [true, '++'],
-            [true, '+++'],
-            [true, '++++'],
-            [true, '+++++'],
-
-            [false, ''],
-            [false, ' '],
-            [false, ' 0'],
-            [false, '0 '],
-            [false, false],
-            [false, null],
-            [false, 0],
-            [false, '0'],
-            [false, '0.'],
-            [false, '0.0'],
-            [false, '0.00'],
-            [false, 'false'],
-            [false, 'no'],
-            [false, 'n'],
-            [false, 'non'],
-            [false, 'faux'],
-            [false, 'НЕТ'],
-            [false, '-'],
-        ];
     }
 
     public function testDigests(): void
@@ -361,5 +252,114 @@ class FilterTest extends PHPUnit
         isSame($obj, Filter::json($obj));
         isSame($data, (array)Filter::json($obj));
         isSame($data, (array)Filter::json($data));
+    }
+
+    public static function provideIntCases(): iterable
+    {
+        return [
+            [0, null],
+            [0, false],
+            [0, ''],
+            [0, 0],
+            [1, 1],
+            [1, '1'],
+            [1, '01'],
+            [-1, '-01'],
+            [-15, ' - 1 5 '],
+            [-17, ' - 1 asd 7 '],
+            [-1, ' - 1 . 0 '],
+            [-1, ' - 1 , 5 '],
+            [-1, ' - 1 - 0 '],
+            [3, ' + 3'],
+            [-4, ' - 4'],
+            [-5, ' +- 5'],
+            [6, ' -+ 6'],
+        ];
+    }
+
+    public static function provideFloatCases(): iterable
+    {
+        return [
+            [0.0, null],
+            [0.0, false],
+            [0.0, ''],
+            [0.0, 'asdasd'],
+            [0.0, 0],
+            [1.0, 1],
+            [123456789.0, 123456789],
+            [1.0, '1'],
+            [1.0, '01'],
+            [-1.0, '-01'],
+            [-10.0, ' - 1 0 '],
+            [-1.5, ' - 1,5 '],
+            [-1.5, ' - 1.5 '],
+            [-1.512, ' - 1.5123 ', 3],
+            [-15123.0, ' - 1 asd 5123 ', 3],
+            [15123.0, ' + 1 asd 5123 ', 3],
+
+            [-12.451, 'abc-12,451'],
+            [-12.452, 'abc-12.452'],
+            [-12.453, '-abc12.453'],
+            [-12.454, 'abc-12.454abc'],
+            [-12.455, 'abc-12. 455'],
+            [-12.456, 'abc-12. 456 .7'],
+            [2.6e-19, '26.3e-20', 20],
+            [2.53E-19, '25.3e-20', 100],
+            [2.4e-9, '24.3e-10'],
+        ];
+    }
+
+    public static function provideBoolCases(): iterable
+    {
+        return [
+            [true, '1'],
+            [true, ' 1'],
+            [true, '1 '],
+            [true, '10'],
+            [true, '-1'],
+            [true, true],
+            [true, 27],
+            [true, 1.0],
+            [true, -1],
+            [true, -1.0],
+            [true, 10],
+            [true, 10.0],
+            [true, 10.0],
+            [true, 'true'],
+            [true, 'TRUE'],
+            [true, 'yes'],
+            [true, 'YES'],
+            [true, 'y'],
+            [true, 'Y'],
+            [true, 'oui'],
+            [true, 'vrai'],
+            [true, 'ДА'],
+            [true, 'Д'],
+            [true, '*'],
+            [true, '+'],
+            [true, '++'],
+            [true, '+++'],
+            [true, '++++'],
+            [true, '+++++'],
+
+            [false, ''],
+            [false, ' '],
+            [false, ' 0'],
+            [false, '0 '],
+            [false, false],
+            [false, null],
+            [false, 0],
+            [false, '0'],
+            [false, '0.'],
+            [false, '0.0'],
+            [false, '0.00'],
+            [false, 'false'],
+            [false, 'no'],
+            [false, 'n'],
+            [false, 'non'],
+            [false, 'faux'],
+            [false, 'НЕТ'],
+            [false, '-'],
+        ];
     }
 }

--- a/tests/TimerTest.php
+++ b/tests/TimerTest.php
@@ -53,7 +53,7 @@ class TimerTest extends PHPUnit
         isTrue(Timer::timeSinceStart() > 0);
     }
 
-    public function provideSecondsToTimeStringInMillisecondCases(): iterable
+    public static function provideSecondsToTimeStringInMillisecondCases(): iterable
     {
         return [
             ['1 000 ms', 1],
@@ -72,7 +72,7 @@ class TimerTest extends PHPUnit
         ];
     }
 
-    public function provideSecondsToTimeStringCases(): iterable
+    public static function provideSecondsToTimeStringCases(): iterable
     {
         return [
             ['0 ms', 0],


### PR DESCRIPTION
Changed the test data providers in EmailTest, EnvTest, FilterTest, and TimerTest classes to be static. This approach allows these methods to be called without creating the test class instances, improving overall testing performance.