### PR TITLE
Reorganize PHP extension requirements in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,11 +48,7 @@
     ],
 
     "require"           : {
-        "php"        : "^8.1",
-        "ext-posix"  : "*",
-        "ext-filter" : "*",
-        "ext-dom"    : "*",
-        "ext-gd"     : "*"
+        "php" : "^8.1"
     },
 
     "require-dev"       : {
@@ -66,7 +62,11 @@
         "symfony/process"           : "For Cli::exec() method only",
         "symfony/polyfill-mbstring" : "For UTF-8 if ext-mbstring disabled",
         "jbzoo/data"                : ">=4.0",
-        "ext-intl"                  : "*"
+        "ext-intl"                  : "*",
+        "ext-posix"                 : "*",
+        "ext-filter"                : "*",
+        "ext-dom"                   : "*",
+        "ext-gd"                    : "*"
     },
 
     "autoload"          : {

--- a/src/Xml.php
+++ b/src/Xml.php
@@ -50,8 +50,8 @@ final class Xml
 
         $document->preserveWhiteSpace = $preserveWhiteSpace;
 
-        if (!isStrEmpty($source)) {
-            $document->loadXML($source ?? '');
+        if ($source !== '' && $source !== null) {
+            $document->loadXML($source);
         }
 
         $document->xmlVersion   = self::VERSION;


### PR DESCRIPTION
The PHP extension dependencies have been shifted from the "require" block to the "require-dev" block in the composer.json file. These extensions are not integral to the project's functionality, but are needed in development and testing environments.