### PR TITLE
Support negative byte values in FS::format method

### DIFF
--- a/src/FS.php
+++ b/src/FS.php
@@ -284,22 +284,19 @@ final class FS
      */
     public static function format(int $bytes, int $decimals = 2): string
     {
-        $exp     = 0;
-        $value   = 0;
+        $isNegative = $bytes < 0;
+
         $symbols = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
-        $bytes = (float)$bytes;
-
-        if ($bytes > 0) {
-            $exp   = (int)\floor(\log($bytes) / \log(1024));
-            $value = ($bytes / (1024 ** \floor($exp)));
-        }
+        $bytes = \abs((float)$bytes);
+        $exp   = (int)\floor(\log($bytes) / \log(1024));
+        $value = ($bytes / (1024 ** \floor($exp)));
 
         if ($symbols[$exp] === 'B') {
             $decimals = 0;
         }
 
-        return \number_format($value, $decimals, '.', '') . ' ' . $symbols[$exp];
+        return ($isNegative ? '-' : '') . \number_format($value, $decimals, '.', '') . ' ' . $symbols[$exp];
     }
 
     /**

--- a/tests/FileSystemTest.php
+++ b/tests/FileSystemTest.php
@@ -284,8 +284,17 @@ class FileSystemTest extends PHPUnit
 
     public function testFormat(): void
     {
+        $size = FS::format(0);
+        is('0 B', $size);
+
+        $size = FS::format(0, 0);
+        is('0 B', $size);
+
         $size = FS::format(512, 0);
         is('512 B', $size);
+
+        $size = FS::format(-512, 0);
+        is('-512 B', $size);
 
         $size = FS::format(512);
         is('512 B', $size);
@@ -298,6 +307,9 @@ class FileSystemTest extends PHPUnit
 
         $size = FS::format(19971597926);
         is('18.60 GB', $size);
+
+        $size = FS::format(-19971597926);
+        is('-18.60 GB', $size);
 
         $size = FS::format(2748779069440, 1);
         is('2.5 TB', $size);


### PR DESCRIPTION
The FS::format method in the FS.php file has been updated to support negative byte values. Additionally, relevant test cases were added in FileSystemTest.php to ensure correct operation. This change is expected to provide more flexible data formatting capabilities.