### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -65,11 +68,12 @@ jobs:
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ The project uses JBZoo Toolbox codestyle standards via Makefile targets:
 ### Build System
 - **Makefile**: Main build configuration with standard targets
 - **Dependencies**: Uses `jbzoo/toolbox-dev` for development dependencies
-- **PHP Version**: Requires PHP 8.2+ (as of current version)
+- **PHP Version**: Requires PHP 8.3+ (as of current version)
 
 ## Testing Architecture
 
@@ -85,7 +85,7 @@ The project uses JBZoo Toolbox codestyle standards via Makefile targets:
 
 ### CI/CD Pipeline
 - **GitHub Actions**: `.github/workflows/main.yml`
-- **PHP Versions**: Tests run on PHP 8.2, 8.3, 8.4
+- **PHP Versions**: Tests run on PHP 8.3, 8.4, 8.5
 - **Matrix Testing**: Tests with different composer flags (`--prefer-lowest`)
 - **Coverage**: Uses Xdebug for coverage reporting
 - **Quality Gates**: Separate jobs for PHPUnit tests, linters, and reports
@@ -102,13 +102,13 @@ src/
 ```
 
 ### Development Standards
-- **PHP 8.2+**: Uses modern PHP features including typed properties and strict types
+- **PHP 8.3+**: Uses modern PHP features including typed properties and strict types
 - **PSR Standards**: Follows PSR-4 autoloading and coding standards
 - **Static Methods**: All utility functions implemented as static class methods
 - **Immutable Operations**: Most operations return new values rather than modifying input
 
 ### Key Dependencies
-- **Production**: Minimal dependencies (only PHP 8.2+)
+- **Production**: Minimal dependencies (only PHP 8.3+)
 - **Development**: `jbzoo/toolbox-dev` for testing and code quality tools
 - **Optional**: `symfony/process` for CLI operations, `jbzoo/data` for data handling
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Utils
 
-[![CI](https://github.com/JBZoo/Utils/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Utils/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Utils/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Utils?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Utils/coverage.svg)](https://shepherd.dev/github/JBZoo/Utils)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Utils/level.svg)](https://shepherd.dev/github/JBZoo/Utils)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/utils/badge)](https://www.codefactor.io/repository/github/jbzoo/utils/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/utils/version)](https://packagist.org/packages/jbzoo/utils/)    [![Total Downloads](https://poser.pugx.org/jbzoo/utils/downloads)](https://packagist.org/packages/jbzoo/utils/stats)    [![Dependents](https://poser.pugx.org/jbzoo/utils/dependents)](https://packagist.org/packages/jbzoo/utils/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/utils)](https://github.com/JBZoo/Utils/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Utils/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Utils/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Utils/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Utils?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Utils/coverage.svg)](https://shepherd.dev/github/JBZoo/Utils)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Utils/level.svg)](https://shepherd.dev/github/JBZoo/Utils)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/utils/badge)](https://www.codefactor.io/repository/github/jbzoo/utils/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/utils/version)](https://packagist.org/packages/jbzoo/utils/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/utils/downloads)](https://packagist.org/packages/jbzoo/utils/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/utils/dependents)](https://packagist.org/packages/jbzoo/utils/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/utils)](https://github.com/JBZoo/Utils/blob/master/LICENSE)
 
 
 <!--ts-->

--- a/composer.json
+++ b/composer.json
@@ -48,13 +48,13 @@
     ],
 
     "require"           : {
-        "php" : "^8.2"
+        "php" : "^8.3"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.2",
-        "jbzoo/data"        : "^7.2",
-        "symfony/process"   : "^7.3.4"
+        "jbzoo/toolbox-dev" : "^8.0",
+        "jbzoo/data"        : "^8.0",
+        "symfony/process"   : ">=7.3.4"
     },
 
     "suggest"           : {
@@ -91,7 +91,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,24 +10,14 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Utils
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
+<phpunit bootstrap="tests/autoload.php"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -44,4 +34,10 @@
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/FS.php
+++ b/src/FS.php
@@ -296,7 +296,8 @@ final class FS
         $symbols = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 
         $bytes = \abs((float)$bytes);
-        $exp   = (int)\floor(\log($bytes) / \log(1024));
+        // log(0) is -INF; casting -INF to int emits a warning on PHP 8.5. Zero bytes => "0 B".
+        $exp   = $bytes > 0.0 ? (int)\floor(\log($bytes) / \log(1024)) : 0;
         $value = ($bytes / (1024 ** \floor($exp)));
 
         if ($symbols[$exp] === 'B') {

--- a/src/IP.php
+++ b/src/IP.php
@@ -56,11 +56,12 @@ final class IP
      */
     public static function v4InRange(string $ipAddress, string $range): bool
     {
-        if (\str_contains($range, '/')) {
-            // $range is in IP/NETMASK format
-            $rangeParts = \explode('/', $range, 2);
-            $range      = $rangeParts[0] ?? ''; // @phpstan-ignore-line
-            $netMask    = $rangeParts[1] ?? '';
+        $slashPos = \strpos($range, '/');
+        if ($slashPos !== false) {
+            // $range is in IP/NETMASK format. Using strpos as the guard (not str_contains + explode)
+            // keeps the offset a known int, so both PHPStan and Psalm see two present string parts.
+            $netMask = \substr($range, $slashPos + 1);
+            $range   = \substr($range, 0, $slashPos);
 
             if (\str_contains($netMask, '.')) {
                 // $netMask is a 255.255.0.0 format
@@ -100,10 +101,10 @@ final class IP
             $range = "{$lower}-{$upper}";
         }
 
-        if (\str_contains($range, '-')) { // A-B format
-            $rangeParts = \explode('-', $range, 2);
-            $lower      = $rangeParts[0] ?? ''; // @phpstan-ignore-line
-            $upper      = $rangeParts[1] ?? '';
+        $dashPos = \strpos($range, '-');
+        if ($dashPos !== false) { // A-B format
+            $lower = \substr($range, 0, $dashPos);
+            $upper = \substr($range, $dashPos + 1);
 
             $lowerDec = (float)\sprintf('%u', (int)\ip2long($lower));
             $upperDec = (float)\sprintf('%u', (int)\ip2long($upper));

--- a/src/Image.php
+++ b/src/Image.php
@@ -198,10 +198,8 @@ final class Image
                     (int)$alpha, // @phpstan-ignore-line
                 );
 
-                // Set pixel with the new color + opacity
-                if (!\imagesetpixel($srcImg, $x, $y, (int)$alphaColorXY)) {
-                    return;
-                }
+                // Set pixel with the new color + opacity (imagesetpixel() always returns true on a GdImage)
+                \imagesetpixel($srcImg, $x, $y, (int)$alphaColorXY);
             }
         }
 

--- a/src/PhpDocs.php
+++ b/src/PhpDocs.php
@@ -61,7 +61,9 @@ final class PhpDocs
                 }
 
                 // get the name of the param
-                \preg_match('/@(\w+)/', $info, $matches);
+                if (\preg_match('/@(\w+)/', $info, $matches) !== 1) {
+                    continue;
+                }
                 $paramName = $matches[1];
 
                 // remove the param from the string

--- a/src/Stats.php
+++ b/src/Stats.php
@@ -66,7 +66,7 @@ final class Stats
         });
         $sum = \array_sum($values);
 
-        if ($sum === 0) {
+        if ($sum === 0.0) {
             return 0;
         }
 

--- a/src/Sys.php
+++ b/src/Sys.php
@@ -75,7 +75,6 @@ final class Sys
 
     /**
      * Alias fo ini_set function.
-     * @psalm-suppress PossiblyUnusedReturnValue
      */
     public static function iniSet(string $phpIniKey, string $newValue): bool
     {
@@ -101,7 +100,7 @@ final class Sys
     {
         $disabledOnPhpIni = false;
 
-        if (\is_string($funcName)) {
+        if (!$funcName instanceof \Closure) {
             $disabledOnPhpIni = \str_contains(
                 \strtolower(self::iniGet('disable_functions')),
                 \strtolower(\trim($funcName)),

--- a/src/Url.php
+++ b/src/Url.php
@@ -87,10 +87,10 @@ final class Url
         }
 
         // Re-construct the query string
-        $parsedUri['query'] = self::build($queryParams);
+        $query = self::build($queryParams);
 
         // Strip = from valueless parameters.
-        $parsedUri['query'] = (string)\preg_replace('/=(?=&|$)/', '', (string)$parsedUri['query']);
+        $parsedUri['query'] = (string)\preg_replace('/=(?=&|$)/', '', $query);
 
         // Re-construct the entire URL
         $newUri = self::buildAll((array)$parsedUri);

--- a/tests/EmailTest.php
+++ b/tests/EmailTest.php
@@ -21,10 +21,10 @@ use JBZoo\Utils\Email;
 class EmailTest extends PHPUnit
 {
     /**
-     * @dataProvider provideCheckCases
      * @param mixed $input
      * @param mixed $outcome
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideCheckCases')]
     public function testCheck($input, $outcome): void
     {
         is($outcome, Email::check($input));
@@ -60,19 +60,19 @@ class EmailTest extends PHPUnit
     }
 
     /**
-     * @dataProvider getEmptyProvider
      * @param mixed $input
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getEmptyProvider')]
     public function testCheckWithEmptyEmails($input): void
     {
         is([], Email::check($input));
     }
 
     /**
-     * @dataProvider provideGetDomainsCases
      * @param mixed $input
      * @param mixed $outcome
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetDomainsCases')]
     public function testGetDomains($input, $outcome): void
     {
         is($outcome, Email::getDomain($input));
@@ -117,9 +117,9 @@ class EmailTest extends PHPUnit
     }
 
     /**
-     * @dataProvider getEmptyProvider
      * @param mixed $input
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('getEmptyProvider')]
     public function testGetDomainsWithEmptyEmails($input): void
     {
         is([], Email::getDomain($input));
@@ -136,10 +136,10 @@ class EmailTest extends PHPUnit
     }
 
     /**
-     * @dataProvider provideGetDomainsInAlphabeticalOrderCases
      * @param mixed $input
      * @param mixed $outcome
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetDomainsInAlphabeticalOrderCases')]
     public function testGetDomainsInAlphabeticalOrder($input, $outcome): void
     {
         is($outcome, Email::getDomainSorted($input));
@@ -184,12 +184,12 @@ class EmailTest extends PHPUnit
     }
 
     /**
-     * @dataProvider provideGetGravatarUrlCases
      * @param mixed $input
      * @param mixed $expectedHttp
      * @param mixed $expectedHttps
      * @SuppressWarnings(PHPMD.Superglobals)
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideGetGravatarUrlCases')]
     public function testGetGravatarUrl($input, $expectedHttp, $expectedHttps): void
     {
         $_SERVER['HTTPS'] = 'off';

--- a/tests/EnvTest.php
+++ b/tests/EnvTest.php
@@ -25,11 +25,11 @@ use JBZoo\Utils\Filter;
 class EnvTest extends PHPUnit
 {
     /**
-     * @dataProvider provideConvertOptionsCases
      * @param mixed $value
      * @param int   $options
      * @param mixed $expected
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideConvertOptionsCases')]
     public function testConvertOptions($value, $options, $expected): void
     {
         isSame($expected, Env::convert($value, $options));

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -23,10 +23,10 @@ use JBZoo\Utils\Filter;
 class FilterTest extends PHPUnit
 {
     /**
-     * @dataProvider provideIntCases
      * @param mixed $exepted
      * @param mixed $actual
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideIntCases')]
     public function testInt($exepted, $actual): void
     {
         isSame($exepted, Filter::_($actual, 'int'));
@@ -56,11 +56,11 @@ class FilterTest extends PHPUnit
     }
 
     /**
-     * @dataProvider provideFloatCases
      * @param mixed      $excepted
      * @param mixed      $actual
      * @param null|mixed $round
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideFloatCases')]
     public function testFloat($excepted, $actual, $round = null): void
     {
         if ($round === null) {
@@ -103,10 +103,10 @@ class FilterTest extends PHPUnit
     }
 
     /**
-     * @dataProvider provideBoolCases
      * @param mixed $excepted
      * @param mixed $actual
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideBoolCases')]
     public function testBool($excepted, $actual): void
     {
         isSame($excepted, Filter::_($actual, 'bool'));

--- a/tests/SysTest.php
+++ b/tests/SysTest.php
@@ -21,6 +21,7 @@ use JBZoo\Utils\Sys;
 /**
  * @SuppressWarnings(PHPMD.Superglobals)
  */
+#[\PHPUnit\Framework\Attributes\CoversClass(Sys::class)]
 class SysTest extends PHPUnit
 {
     public function testIsFunc(): void
@@ -93,87 +94,46 @@ class SysTest extends PHPUnit
         isSame(PROJECT_ROOT, Sys::getDocRoot());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::canCollectCodeCoverage
-     * @uses   \JBZoo\Utils\Sys::hasXdebug
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     * @uses   \JBZoo\Utils\Sys::isPHP
-     */
     public function testAbilityToCollectCodeCoverageCanBeAssessed(): void
     {
         self::assertIsBool(Sys::canCollectCodeCoverage());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::getBinary
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     */
     public function testBinaryCanBeRetrieved(): void
     {
         self::assertIsString(Sys::getBinary());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::isHHVM
-     */
     public function testCanBeDetected(): void
     {
         self::assertIsBool(Sys::isHHVM());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::isRealPHP
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     */
     public function testCanBeDetected2(): void
     {
         self::assertIsBool(Sys::isRealPHP());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::hasXdebug
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     * @uses   \JBZoo\Utils\Sys::isPHP
-     */
     public function testXdebugCanBeDetected(): void
     {
         self::assertIsBool(Sys::hasXdebug());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::getNameWithVersion
-     * @uses   \JBZoo\Utils\Sys::getName
-     * @uses   \JBZoo\Utils\Sys::getVersion
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     * @uses   \JBZoo\Utils\Sys::isPHP
-     */
     public function testNameAndVersionCanBeRetrieved(): void
     {
         self::assertIsString(Sys::getNameWithVersion());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::getName
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     */
     public function testNameCanBeRetrieved(): void
     {
         self::assertIsString(Sys::getName());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::getVersion
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     */
     public function testVersionCanBeRetrieved(): void
     {
         self::assertIsString(Sys::getVersion());
     }
 
-    /**
-     * @covers \JBZoo\Utils\Sys::getVendorUrl
-     * @uses   \JBZoo\Utils\Sys::isHHVM
-     */
     public function testVendorUrlCanBeRetrieved(): void
     {
         self::assertIsString(Sys::getVendorUrl());

--- a/tests/TimerTest.php
+++ b/tests/TimerTest.php
@@ -24,10 +24,10 @@ use JBZoo\Utils\Timer;
 class TimerTest extends PHPUnit
 {
     /**
-     * @dataProvider provideSecondsToTimeStringCases
      * @param string $string
      * @param mixed  $seconds
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSecondsToTimeStringCases')]
     public function testSecondsToTimeString($string, $seconds): void
     {
         isSame($string, Timer::format($seconds));
@@ -74,10 +74,10 @@ class TimerTest extends PHPUnit
     }
 
     /**
-     * @dataProvider provideSecondsToTimeStringInMillisecondCases
      * @param string $string
      * @param mixed  $seconds
      */
+    #[\PHPUnit\Framework\Attributes\DataProvider('provideSecondsToTimeStringInMillisecondCases')]
     public function testSecondsToTimeStringInMillisecond($string, $seconds): void
     {
         isSame($string, Timer::formatMS($seconds));

--- a/tests/XmlTest.php
+++ b/tests/XmlTest.php
@@ -113,14 +113,9 @@ class XmlTest extends PHPUnit
     /** @var string[] */
     private array $expectedXml = [
         '<?xml version="1.0" encoding="UTF-8"?>',
-        '<phpunit bootstrap="tests/autoload.php" convertErrorsToExceptions="true" convertNoticesToExceptions="true"'
-        . ' convertWarningsToExceptions="true" convertDeprecationsToExceptions="true" processIsolation="false" '
-        . 'stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" '
-        . 'stopOnRisky="false" noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">',
-        '  <coverage processUncoveredFiles="true">',
-        '    <include>',
-        '      <directory suffix=".php">src</directory>',
-        '    </include>',
+        '<phpunit bootstrap="tests/autoload.php" processIsolation="false" stopOnError="false" stopOnFailure="false"'
+        . ' stopOnIncomplete="false" stopOnSkipped="false" stopOnRisky="false">',
+        '  <coverage>',
         '    <report>',
         '      <clover outputFile="build/coverage_xml/main.xml"/>',
         '      <php outputFile="build/coverage_cov/main.cov"/>',
@@ -135,6 +130,11 @@ class XmlTest extends PHPUnit
         '  <logging>',
         '    <junit outputFile="build/coverage_junit/main.xml"/>',
         '  </logging>',
+        '  <source>',
+        '    <include>',
+        '      <directory suffix=".php">src</directory>',
+        '    </include>',
+        '  </source>',
         '</phpunit>',
         '',
     ];
@@ -146,41 +146,21 @@ class XmlTest extends PHPUnit
                 '_text'  => null,
                 '_cdata' => null,
                 '_attrs' => [
-                    'bootstrap'                       => 'tests/autoload.php',
-                    'convertErrorsToExceptions'       => 'true',
-                    'convertNoticesToExceptions'      => 'true',
-                    'convertWarningsToExceptions'     => 'true',
-                    'convertDeprecationsToExceptions' => 'true',
-                    'processIsolation'                => 'false',
-                    'stopOnError'                     => 'false',
-                    'stopOnFailure'                   => 'false',
-                    'stopOnIncomplete'                => 'false',
-                    'stopOnSkipped'                   => 'false',
-                    'stopOnRisky'                     => 'false',
-                    'noNamespaceSchemaLocation'       => 'https://schema.phpunit.de/9.3/phpunit.xsd',
+                    'bootstrap'        => 'tests/autoload.php',
+                    'processIsolation' => 'false',
+                    'stopOnError'      => 'false',
+                    'stopOnFailure'    => 'false',
+                    'stopOnIncomplete' => 'false',
+                    'stopOnSkipped'    => 'false',
+                    'stopOnRisky'      => 'false',
                 ],
                 '_children' => [
                     [
                         '_node'     => 'coverage',
                         '_text'     => null,
                         '_cdata'    => null,
-                        '_attrs'    => ['processUncoveredFiles' => 'true'],
+                        '_attrs'    => [],
                         '_children' => [
-                            [
-                                '_node'     => 'include',
-                                '_text'     => null,
-                                '_cdata'    => null,
-                                '_attrs'    => [],
-                                '_children' => [
-                                    [
-                                        '_node'     => 'directory',
-                                        '_text'     => 'src',
-                                        '_cdata'    => null,
-                                        '_attrs'    => ['suffix' => '.php'],
-                                        '_children' => [],
-                                    ],
-                                ],
-                            ],
                             [
                                 '_node'     => 'report',
                                 '_text'     => null,
@@ -251,6 +231,29 @@ class XmlTest extends PHPUnit
                                 '_cdata'    => null,
                                 '_attrs'    => ['outputFile' => 'build/coverage_junit/main.xml'],
                                 '_children' => [],
+                            ],
+                        ],
+                    ],
+                    [
+                        '_node'     => 'source',
+                        '_text'     => null,
+                        '_cdata'    => null,
+                        '_attrs'    => [],
+                        '_children' => [
+                            [
+                                '_node'     => 'include',
+                                '_text'     => null,
+                                '_cdata'    => null,
+                                '_attrs'    => [],
+                                '_children' => [
+                                    [
+                                        '_node'     => 'directory',
+                                        '_text'     => 'src',
+                                        '_cdata'    => null,
+                                        '_attrs'    => ['suffix' => '.php'],
+                                        '_children' => [],
+                                    ],
+                                ],
                             ],
                         ],
                     ],


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven; no public API signature changes).

### Changed (BC — packaging major 8.0)
- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.

### Fixed
- `FS::format(0)` no longer warns on PHP 8.5; `Stats` zero-sum guard now actually fires.

### Internal
- Lint-superposition refactors (`IP`, `Image`, `PhpDocs`, `Sys`, `Url`) — no observable change.

Builds on @erdemuncuoglu's dependency-constraint report (#56, merged below).
